### PR TITLE
Fixed incorrect groupId, which seems to be a copy/paste error.

### DIFF
--- a/ch.flos-freeware/notepad2/4.2.25/gradle.properties
+++ b/ch.flos-freeware/notepad2/4.2.25/gradle.properties
@@ -1,4 +1,4 @@
-group=io.github.conemu
+group=ch.flos-freeware
 version=4.2.25
 
 description=The SEU-as-Code package for Notepad2


### PR DESCRIPTION
Also, the package should be re-published on bintray with the correct groupid, which is now consistent with what README.md claims.
